### PR TITLE
ytplの置換・プレイリスト取得の改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ yarn-error.log*
 # others
 cookies.txt
 cookie.txt
+/tmp

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+# Custom License for @psannetwork's Projects
+
+## Japanese (日本語)
+このリポジトリのプログラム、ドキュメント、および関連資産（以下「本ソフトウェア」）の使用には、以下の条件が適用されます。
+
+1. **再配布の禁止**: 本ソフトウェアの全体または一部を、いかなる形式（ソースコード、バイナリ、コンパイル済みデータ等）でも、第三者に再配布、販売、または公開することを禁止します。
+2. **商用利用の禁止**: 本ソフトウェアを、直接的または間接的に利益を得る目的（販売、有料サービス、広告、企業内利用等）で使用することを禁止します。
+3. **改変の許可（個人利用限定）**: 本ソフトウェアを個人利用の目的で改変（編集）することは許可されます。ただし、改変したソフトウェアを再配布、販売、または公開することは禁止されます。
+4. **免責事項**: 本ソフトウェアは「現状のまま」提供され、いかなる明示的または黙示的な保証も行いません。本ソフトウェアの使用に関連して発生したいかなる損害についても、作者は一切の責任を負いません。
+
+---
+
+## English
+The following terms apply to the use of the programs, documentation, and associated assets in this repository (the "Software").
+
+1. **Prohibition of Redistribution**: Redistribution, sale, or disclosure of the Software, in whole or in part, in any form (source code, binary, compiled data, etc.) to any third party is strictly prohibited.
+2. **Prohibition of Commercial Use**: Use of the Software for any purpose that results in direct or indirect profit (sales, paid services, advertising, corporate use, etc.) is strictly prohibited.
+3. **Permission to Modify (Personal Use Only)**: Modification of the Software for personal use is permitted. However, the redistribution, sale, or disclosure of the modified software is strictly prohibited.
+4. **Disclaimer**: The Software is provided "as is", without warranty of any kind, express or implied. The author shall not be liable for any damages arising in connection with the use of the Software.
+
+---
+© 2026 @psannetwork. All rights reserved.

--- a/fetchPlaylist.js
+++ b/fetchPlaylist.js
@@ -1,5 +1,5 @@
 // fetchPlaylist.js
-const ytpl = require('ytpl');
+const ytpl = require('@distube/ytpl');
 
 // プレイリストを取得する関数
 const fetchPlaylist = async (playlistId) => {

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "preinstall": "sudo apt update && sudo apt install -y yt-dlp"
   },
   "dependencies": {
+    "@distube/ytpl": "^1.2.4",
+    "cors": "^2.8.5",
     "express": "^4.18.2",
-    "ws": "^8.11.0",
-    "uuid": "^9.0.0",
     "tmp": "^0.2.1",
-    "ytpl": "^2.0.0",
-    "cors": "^2.8.5"
+    "uuid": "^9.0.0",
+    "ws": "^8.11.0"
   },
   "devDependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^3.1.14"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/public/index.html
+++ b/public/index.html
@@ -169,7 +169,7 @@ function convertWsToHttp(wsUrl) {
       const playlistMatch = url.match(/(?:\?|\&)list=([^&]+)/);
       if (playlistMatch) {
         const playlistId = playlistMatch[1];
-        const playlistResponse = await fetch(`https://youtubedownload.psannetwork.net/fetch-playlist?playlistId=${playlistId}`);
+        const playlistResponse = await fetch(`/fetch-playlist?playlistId=${playlistId}`);
         const playlistData = await playlistResponse.json();
         const videos = playlistData.videos;
         document.getElementById('request-list').innerHTML = '';

--- a/public/url_list.json
+++ b/public/url_list.json
@@ -1,9 +1,5 @@
 [
   {
-    "name": "sukru",
-    "url": "wss://yt.sukru.top/"
-  },
-  {
     "name": "Psannetwork",
     "url": "wss://youtubedownload.psannetwork.net"
   },
@@ -14,5 +10,9 @@
   {
     "name": "omyu",
     "url": "wss://youtubedl.omyu1116.com"
+  },
+  {
+    "name": "sukru",
+    "url": "wss://yt.sukru.top/"
   }
 ]

--- a/server.js
+++ b/server.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const WebSocket = require('ws');
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
-const fetchPlaylist = require('./fetchPlaylist');
 const cors = require('cors');
+
+const fetchPlaylist = require('./fetchPlaylist');
 
 const app = express();
 const port = 3020;
@@ -16,7 +17,6 @@ if (!fs.existsSync(tmpDir)) {
   fs.mkdirSync(tmpDir, { recursive: true });
 }
 
-const tmpCleanupInterval = 1 * 60 * 60 * 1000;
 setInterval(() => {
   fs.readdir(tmpDir, (err, files) => {
     if (err) return;
@@ -25,90 +25,121 @@ setInterval(() => {
       fs.rm(filePath, { recursive: true, force: true }, () => {});
     });
   });
-}, tmpCleanupInterval);
+}, 60 * 60 * 1000);
 
 wss.on('connection', (ws) => {
-  ws.on('message', (message) => {
-    const { url, format, requestId } = JSON.parse(message);
-    handleDownload(requestId, url, format, ws);
+  ws.on('message', async (message) => {
+    try {
+      const data = JSON.parse(message);
+
+
+      if (data.type === 'fetch_playlist') {
+        const playlistId = new URL(data.url).searchParams.get('list');
+        if (!playlistId) throw new Error('Invalid Playlist URL');
+        
+        const videos = await fetchPlaylist(playlistId);
+        ws.send(JSON.stringify({ type: 'playlist_info', videos }));
+        return;
+      }
+
+      // 2. ダウンロード実行リクエスト
+      const { url, format, requestId } = data;
+      handleDownload(requestId, url, format, ws);
+
+    } catch (err) {
+      ws.send(JSON.stringify({ type: 'error', message: 'リクエストの解析に失敗しました' }));
+    }
   });
 });
 
 function handleDownload(requestId, url, format, ws) {
-  const isPlaylist = /[?&]list=/.test(url);
-  const randomDir = path.join(tmpDir, generateRandomString(10));
+  
+  if (!url.startsWith('http')) {
+    return ws.send(JSON.stringify({ type: 'error', requestId, message: '不正なURLです' }));
+  }
+
+  const randomDirName = generateRandomString(16);
+  const randomDir = path.join(tmpDir, randomDirName);
   fs.mkdirSync(randomDir, { recursive: true });
-  const baseCommand = `yt-dlp ${isPlaylist ? '--yes-playlist' : ''}`;
-  const cookieOption = fs.existsSync('cookie.txt') ? '--cookies cookie.txt' : '';
-  const outputTemplate = path.join(randomDir, '%(title)s.%(ext)s');
-  const command = format === 'mp4'
-    ? `${baseCommand} ${cookieOption} -f bestvideo[ext=mp4]+bestaudio[ext=m4a] --merge-output-format mp4 -o "${outputTemplate}" "${url}"`
-    : `${baseCommand} ${cookieOption} -f bestaudio --extract-audio --audio-format mp3 -o "${outputTemplate}" "${url}"`;
-  const process = exec(command);
-  process.stdout.on('data', (data) => {
-    const match = data.match(/(\d+(\.\d+)?)%/);
+
+
+  const args = [
+    '--no-playlist', 
+    '-f', format === 'mp4' ? 'bestvideo[ext=mp4]+bestaudio[ext=m4a]' : 'bestaudio',
+    '-o', `${randomDir}/%(title)s.%(ext)s`,
+    '--no-mtime',
+    url
+  ];
+
+  if (format === 'mp4') {
+    args.push('--merge-output-format', 'mp4');
+  } else {
+    args.push('--extract-audio', '--audio-format', 'mp3');
+  }
+
+  if (fs.existsSync('cookie.txt')) {
+    args.push('--cookies', 'cookie.txt');
+  }
+
+
+  const child = spawn('yt-dlp', args);
+
+  child.stdout.on('data', (data) => {
+    const match = data.toString().match(/(\d+(\.\d+)?)%/);
     if (match) {
       ws.send(JSON.stringify({ type: 'progress', requestId, percentage: match[1] }));
     }
   });
-  process.on('close', (code) => {
+
+  child.on('close', (code) => {
     if (code === 0) {
       const files = fs.readdirSync(randomDir).map((file) => {
-        const safeFileName = sanitizeFileName(file);
+        // 削除
+        const safeFileName = file.replace(/[\/\\:*?"<>|]/g, '_');
         return {
           fileName: safeFileName,
-          fileUrl: `/download/${path.basename(randomDir)}/${encodeURIComponent(safeFileName)}`
+          fileUrl: `/download/${randomDirName}/${encodeURIComponent(safeFileName)}`
         };
       });
       ws.send(JSON.stringify({ type: 'complete', requestId, files }));
+
+      // 一時ファイル消し消し
       setTimeout(() => {
         fs.rmSync(randomDir, { recursive: true, force: true });
       }, 600000);
     } else {
-      ws.send(JSON.stringify({ type: 'error', requestId, message: 'ダウンロードに失敗しました' }));
+      ws.send(JSON.stringify({ type: 'error', requestId, message: 'yt-dlpがエラーを返しました' }));
+      fs.rmSync(randomDir, { recursive: true, force: true });
     }
   });
-}
-
-function sanitizeFileName(fileName) {
-  return fileName.replace(/[\/\\:*?"<>|]/g, '_');
 }
 
 function generateRandomString(length) {
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  return Array.from({ length }, () => characters.charAt(Math.floor(Math.random() * characters.length))).join('');
+  return require('crypto').randomBytes(length).toString('hex').slice(0, length);
 }
 
-app.use(express.static('public'));
+// でぃれくととらばーさる？を無効に
+app.get('/download/:dir/:file', (req, res) => {
+  const { dir, file } = req.params;
+  // path.basename
+  const safeDir = path.basename(dir);
+  const safeFile = path.basename(file);
+  const filePath = path.join(tmpDir, safeDir, safeFile);
 
-app.get('/fetch-playlist', async (req, res) => {
-  const { playlistId } = req.query;
-  if (!playlistId) return res.status(400).json({ error: 'playlistIdが必要です' });
-  try {
-    const videos = await fetchPlaylist(playlistId);
-    res.json({ videos });
-  } catch (error) {
-    res.status(500).json({ error: 'プレイリストの取得に失敗しました' });
+  if (fs.existsSync(filePath)) {
+    res.download(filePath);
+  } else {
+    res.status(404).send('File not found');
   }
 });
 
-app.get('/download/:dir/:file', (req, res) => {
-  const { dir, file } = req.params;
-  const filePath = path.join(tmpDir, dir, file);
-  fs.access(filePath, fs.constants.F_OK, (err) => {
-    if (err) {
-      res.status(404).send('ファイルが見つかりません');
-      return;
-    }
-    res.download(filePath);
-  });
+app.use(express.static('public'));
+
+const server = app.listen(port, () => {
+  console.log(`Secure Server is running on http://localhost:${port}`);
 });
 
-app.server = app.listen(port, () => {
-  console.log(`Server is running on http://localhost:${port}`);
-});
-
-app.server.on('upgrade', (req, socket, head) => {
+server.on('upgrade', (req, socket, head) => {
   wss.handleUpgrade(req, socket, head, (ws) => {
     wss.emit('connection', ws, req);
   });


### PR DESCRIPTION
ytplが廃止されてたのでDisTubeのytplフォークに置き換えました。
各ホストからプレイリストが取得できなくなっていたため、index.htmlのfetch-playlistを相対リンクにしました。